### PR TITLE
refactor: replace console by logging util

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "prepack": "yarn build",
     "prebuild": "rm -rf dist",
+    "cli": "$SHELL ./script/run",
     "lint": "rome format src tests && rome check src tests",
     "lint:fix": "rome format src tests --write && rome check src tests --apply",
     "types:check": "yarn tsc --project . --noEmit",

--- a/script/run
+++ b/script/run
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+rm -rf integration-build.tgz dist
+yarn pack --out integration-build.tgz
+
+mkdir .tmp
+
+echo "{}" > .tmp/package.json
+touch .tmp/yarn.lock
+
+(
+    cd .tmp
+    yarn cache clean
+    yarn add ../integration-build.tgz ts-node
+    yarn womm "$@"
+)
+
+rm -rf .tmp

--- a/script/test-suite
+++ b/script/test-suite
@@ -7,6 +7,8 @@
 # environment and run the test suite with it.
 #
 
+
+rm -rf integration-build.tgz dist
 yarn pack --out integration-build.tgz
 
 mkdir .tests
@@ -16,6 +18,7 @@ touch .tests/yarn.lock
 
 (
     cd .tests
+    yarn cache clean
     yarn add ../integration-build.tgz ts-node
     yarn womm ../tests --ts --workers=2
 )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,10 @@ import parseArgs from './argumentParser'
 import { getContext, redText, assertTsNodeInstall } from './utils'
 import run from './runner'
 
+import createLogger from './logging'
+
+const logger = createLogger()
+
 /*
  * Logic executed when running the test runner CLI.
  */
@@ -10,7 +14,7 @@ import run from './runner'
 	const args = parseArgs(process.argv)
 
 	if (args.help) {
-		console.log(helpText)
+		logger.logRaw(helpText)
 		return
 	}
 
@@ -21,7 +25,7 @@ import run from './runner'
 	try {
 		run(args, context)
 	} catch (e) {
-		console.log(redText('Test run failed'))
+		logger.logError('Test run failed')
 		throw e
 	}
 })().catch((e) => {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,5 +1,11 @@
 import { redText, greenText, yellowText } from './utils'
 
+/*
+ * Standard logger for anything that needs to print messages to the user.
+ *
+ * This supports the same general functionality as the `Console` logger,
+ * including `group` and various levels of logging.
+ */
 class Logger {
 	indent: number = 0
 
@@ -32,9 +38,9 @@ class Logger {
 		process.stdout.write(this.#formatMessage(`${this.#indentPrefix}${text}\n`))
 	}
 
-    logRaw(text: string) {
-        process.stdout.write(`${text}\n`)
-    }
+	logRaw(text: string) {
+		process.stdout.write(`${text}\n`)
+	}
 }
 
 export default () => new Logger()

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,36 @@
+import { redText, greenText, yellowText } from './utils'
+
+class Logger {
+	indent: number = 0
+
+	get #indentPrefix(): string {
+		return '  '.repeat(this.indent)
+	}
+
+	#formatMessage(text: string): string {
+		return `[${new Date().toLocaleString()}] ${text}`
+	}
+
+	group(label: string) {
+		process.stdout.write(this.#formatMessage(`${label}\n`))
+		this.indent += 1
+	}
+
+	groupEnd() {
+		if (this.indent > 0) this.indent -= 1
+	}
+
+	logError(text: string) {
+		process.stdout.write(this.#formatMessage(`${this.#indentPrefix}${redText(text)}\n`))
+	}
+
+	logWarning(text: string) {
+		process.stdout.write(`${this.#indentPrefix}${yellowText(text)}\n`)
+	}
+
+	log(text: string) {
+		process.stdout.write(this.#formatMessage(`${this.#indentPrefix}${text}\n`))
+	}
+}
+
+export default () => new Logger()

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -31,6 +31,10 @@ class Logger {
 	log(text: string) {
 		process.stdout.write(this.#formatMessage(`${this.#indentPrefix}${text}\n`))
 	}
+
+    logRaw(text: string) {
+        process.stdout.write(`${text}\n`)
+    }
 }
 
 export default () => new Logger()

--- a/src/testContext.ts
+++ b/src/testContext.ts
@@ -2,6 +2,10 @@ import { performance } from 'perf_hooks'
 import { redText, greenText } from './utils'
 import { type TestCaseLabel, type TestCaseFunction } from './types'
 
+import createLogger from './logging'
+
+const logger = createLogger()
+
 let _testContext: TestContext | undefined | null
 
 export function getTestContext(): TestContext {
@@ -42,14 +46,14 @@ export class TestContext {
 			test()
 		} catch (e) {
 			hasFailed = true
-			console.log(redText(String(e)))
+			logger.logError(String(e))
 		}
 
 		performance.mark(`test-${label}:end`)
 		const testDuration = performance.measure(`test-${label}`, `test-${label}:start`, `test-${label}:end`).duration
 
-		if (hasFailed) console.log(redText(`❌ [FAILED] ${label} (${(testDuration / 1000).toFixed(3)}s)`))
-		else console.log(greenText(`✅ [PASS] ${label} (${(testDuration / 1000).toFixed(3)}s)`))
+		if (hasFailed) logger.logError(redText(`❌ [FAILED] ${label} (${(testDuration / 1000).toFixed(3)}s)`))
+		else logger.log(greenText(`✅ [PASS] ${label} (${(testDuration / 1000).toFixed(3)}s)`))
 	}
 
 	runTests() {
@@ -60,9 +64,9 @@ export class TestContext {
 
 		for (const child of this.children) {
 			const [label, childContext] = child
-			console.group(greenText(label))
+			logger.group(greenText(label))
 			childContext.runTests()
-			console.groupEnd()
+			logger.groupEnd()
 		}
 	}
 


### PR DESCRIPTION
Usage of `console` here and there is a bit dicey and doesn't offer enough flexibility for log levels and verbosity control. Moving this to a `Logger` proper that will later include level and verbosity control awareness is the main change here.