### PR TITLE
feat: basic beforeEach, afterEach support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as test, it } from './testComponents/test'
 export { default as describe } from './testComponents/describe'
 export { default as expect } from './testComponents/expect'
+export { beforeEach, afterEach } from './testComponents/hooks'

--- a/src/testComponents/hooks.ts
+++ b/src/testComponents/hooks.ts
@@ -1,0 +1,9 @@
+import { getTestContext } from '../testContext'
+
+export function beforeEach(func: () => void) {
+	getTestContext().addBeforeEach(func)
+}
+
+export function afterEach(func: () => void) {
+	getTestContext().addAfterEach(func)
+}

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert'
+
+import { test, describe, beforeEach, afterEach, expect } from 'works-on-my-machine'
+
+describe('Test group lifecycle hooks', () => {
+	let outer: boolean = false
+
+	beforeEach(() => {
+		outer = true
+	})
+
+	afterEach(() => {
+		outer = false
+	})
+
+	describe('beforeEach', () => {
+		let inner: boolean = false
+
+		beforeEach(() => {
+			inner = true
+		})
+
+		afterEach(() => {
+			inner = false
+		})
+
+		test('all beforeEach side-effects run before each test runs', () => {
+			expect(inner).toBe(true)
+			expect(outer).toBe(true)
+		})
+	})
+})


### PR DESCRIPTION
Introduces `beforeEach` and `afterEach` hooks that can be defined _once_ in each `describe`.

Redefining those throws, and they support nested `describe` blocks.